### PR TITLE
Async initialization, and only send mode change packet on change

### DIFF
--- a/dukaonesdk/device.py
+++ b/dukaonesdk/device.py
@@ -1,4 +1,5 @@
 """Implements the duka one device class """
+import asyncio
 import time
 from .mode import Mode
 from .speed import Speed
@@ -107,3 +108,8 @@ class Device:
         timeout = time.time() + 2
         while self.firmware_version is None and time.time() < timeout:
             time.sleep(0.1)
+
+    async def wait_for_initialize_async(self):
+        timeout = time.time() + 2
+        while self.firmware_version is None and time.time() < timeout:
+            await asyncio.sleep(0.1)

--- a/dukaonesdk/dukaclient.py
+++ b/dukaonesdk/dukaclient.py
@@ -122,7 +122,7 @@ class DukaClient:
 
     def set_mode(self, device: Device, mode: Mode):
         """Set the mode of the specified device"""
-        if device.mode == Mode:
+        if device.mode == mode:
             return
         packet = DukaPacket()
         packet.initialize_mode_cmd(device, mode)

--- a/dukaonesdk/dukaclient.py
+++ b/dukaonesdk/dukaclient.py
@@ -1,4 +1,5 @@
 """Implements a client for making a udp connection to the duka one devices """
+
 import socket
 import threading
 import time
@@ -56,7 +57,7 @@ class DukaClient:
             del self._devices[device_id]
         return device
 
-    def get_device(self, device_id: str) -> Device:
+    def get_device(self, device_id: str) -> Device | None:
         """Get a device by device id."""
         if device_id not in self._devices:
             return None
@@ -141,7 +142,7 @@ class DukaClient:
         Returns None if the device does not exist
         Returns the Device object if it exist
         """
-        device: Device = self.get_device(device_id)
+        device: Device | None = self.get_device(device_id)
         # Is the device already added
         if device is not None:
             return device
@@ -183,7 +184,7 @@ class DukaClient:
             self._sock.sendto(data, (device.ip_address, 4000))
 
     def __wait_for_socket(self):
-        """Wait for notify thread to create socket """
+        """Wait for notify thread to create socket"""
         if self._socket_listening:
             return
         timeout = time.time() + 3
@@ -195,7 +196,7 @@ class DukaClient:
                 raise Exception("Timeout waiting for socket connection")
 
     def __print_data(self, data):
-        """Print data in hex - for debugging purpose """
+        """Print data in hex - for debugging purpose"""
         print("".join("{:02x}".format(x) for x in data))
 
     def __open_socket(self):
@@ -281,7 +282,7 @@ class DukaClient:
         """Update the device with data recieved. Called by the dukaclient"""
         haschange = False
         if device._ip_address is not None and ip_address != device._ip_address:
-            self._ip_address = ip_address
+            device._ip_address = ip_address
             haschange = True
         if packet.speed is not None and packet.speed != device._speed:
             device._speed = packet.speed

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # Introduction
 
 This is a Python module for making a connection to a Duka One S6W.
-The Duka One is a one room ventilationsystem with a heat exchanger. It is a Danish product and youi can read more about it [here](
+The Duka One is a one room ventilationsystem with a heat exchanger. It is a Danish product and you can read more about it [here](
 https://dukaventilation.dk/produkter/1-rums-ventilationsloesninger/duka-one-s6w). It may be sold in other countries too. 
 I did contact the manufacture to get more information in case they aready have a public API for connection to the device, but I did not get any reply at all.
 All the information about how to communicate with the device has been extracted by looking at the packages send to/from the device, so there are still some unknon data in the packets.I have it working on 2 devices so I assume it is ok.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="dukaonesdk",
-    version="1.0.4",
+    version="1.0.5",
     description="Duka One ventilation SDK",
     long_description=(
         "SDK for connection to the Duka One S6W ventilation. "


### PR DESCRIPTION
When setting the mode, a packet will only be send to the device if the mode has actually changed (to prevent unnecessary beeps)